### PR TITLE
Update charter.md to use neutral Cloud/Edge terms

### DIFF
--- a/proposals/cloudedgeclientCG/charter.md
+++ b/proposals/cloudedgeclientCG/charter.md
@@ -9,15 +9,15 @@
 
 ## Goals
 
-The mission of this group is to explore mechanisms and interfaces between Central Cloud, Edge-Cloud, and Client for computing workload offloading and orchestration. 
+The mission of this group is to explore mechanisms and interfaces between Cloud, Edge, and Client for computing workload offloading and orchestration. 
 The typical use cases include AI acceleration, cloud gaming, and streaming acceleration. The goal is to explore the feasibility of defining a set of new APIs and mechanisms 
-that enable computing workload offloading and orchestration between Central Cloud, Edge Cloud, and Client. It should leverage existing mechanisms as much as possible 
+that enable computing workload offloading and orchestration between Cloud, Cloud, and Client. It should leverage existing mechanisms as much as possible 
 and should coordinate with related W3C working groups and other SDOs and open-source communities if necessary.
 
 ## Scope of Work
 This group aims to discuss proposals for Cloud-Edge-Client coordination, including:
 * Use cases and requirements for Cloud-Edge-Client coordination
-* Proposals for APIs and mechanisms that enable computing workload offloading and orchestration between Central Cloud, Edge Cloud, and Client
+* Proposals for APIs and mechanisms that enable computing workload offloading and orchestration between Cloud, Edge, and Client
 * Secure networking and trust model requirements in the context of edge computing and offload to edge.
 
 ## Out of Scope
@@ -38,7 +38,7 @@ The Group will have succeeded if it can achieve the following:
 No Specifications will be produced under the current charter.
 
 ### Non-Normative Reports
-The group may produce other Community Group Reports within the scope of this charter that are not Specifications, for instance use cases, requirements, or white papers.
+The group may produce other Community Group Reports within the scope of this charter that are not Specifications, for instance use cases, requirements, white papers, or draft API or protocol proposals.
 
 ### Test Suites and Other Software
 *{TBD: If there are no plans to create a test suite or other software, please state that and remove the following paragraph. If Github is not being used, then indicate where the license information is. If GitHub is being used link to your LICENSE.md file in the next paragraph.}*

--- a/proposals/cloudedgeclientCG/charter.md
+++ b/proposals/cloudedgeclientCG/charter.md
@@ -11,7 +11,7 @@
 
 The mission of this group is to explore mechanisms and interfaces between Cloud, Edge, and Client for computing workload offloading and orchestration. 
 The typical use cases include AI acceleration, cloud gaming, and streaming acceleration. The goal is to explore the feasibility of defining a set of new APIs and mechanisms 
-that enable computing workload offloading and orchestration between Cloud, Cloud, and Client. It should leverage existing mechanisms as much as possible 
+that enable computing workload offloading and orchestration between Cloud, Edge, and Client. It should leverage existing mechanisms as much as possible 
 and should coordinate with related W3C working groups and other SDOs and open-source communities if necessary.
 
 ## Scope of Work

--- a/proposals/cloudedgeclientCG/charter.md
+++ b/proposals/cloudedgeclientCG/charter.md
@@ -38,7 +38,7 @@ The Group will have succeeded if it can achieve the following:
 No Specifications will be produced under the current charter.
 
 ### Non-Normative Reports
-The group may produce other Community Group Reports within the scope of this charter that are not Specifications, for instance use cases, requirements, and white papers.
+The group may produce other Community Group Reports within the scope of this charter that are not Specifications, for instance use cases, requirements, or white papers.
 
 ### Test Suites and Other Software
 *{TBD: If there are no plans to create a test suite or other software, please state that and remove the following paragraph. If Github is not being used, then indicate where the license information is. If GitHub is being used link to your LICENSE.md file in the next paragraph.}*

--- a/proposals/cloudedgeclientCG/charter.md
+++ b/proposals/cloudedgeclientCG/charter.md
@@ -38,7 +38,7 @@ The Group will have succeeded if it can achieve the following:
 No Specifications will be produced under the current charter.
 
 ### Non-Normative Reports
-The group may produce other Community Group Reports within the scope of this charter that are not Specifications, for instance use cases, requirements, white papers, or draft API or protocol proposals.
+The group may produce other Community Group Reports within the scope of this charter that are not Specifications, for instance use cases, requirements, and white papers.
 
 ### Test Suites and Other Software
 *{TBD: If there are no plans to create a test suite or other software, please state that and remove the following paragraph. If Github is not being used, then indicate where the license information is. If GitHub is being used link to your LICENSE.md file in the next paragraph.}*


### PR DESCRIPTION
Two changes:
1. central-cloud, edge-cloud -> cloud, edge wherever they appear
2. add "draft APIs and protocol proposals" to deliverables after "whitepapers"

Note: it's not defined what a "Specification" is.  It may be interpreted that what I want to do is create a specification.  If this turns out to be the case, we can drop the second point above, discuss what (draft) specifications we want, and modify the charter to add them.   We can still go ahead with drafting them, but we'll have to modify the charter before they can be published.  That's ok with me.